### PR TITLE
chore: add CODEOWNERS file to define repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @panz3r will be requested for review when someone 
+# opens a pull request.
+*       @panz3r
+
+# Owners of the 'go-mod-cache' feature
+/src/go-mod-cache     @panz3r
+/test/go-mod-cache    @panz3r


### PR DESCRIPTION
This PR applies the changes required to comply with new GitHub policies described here: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/